### PR TITLE
Add support for bounded random integer generation.

### DIFF
--- a/lib/chacha.ml
+++ b/lib/chacha.ml
@@ -112,6 +112,9 @@ end = struct
     let next_double t = Common.next_double ~nextu64:next_uint64 t
 
 
+    let next_bounded_uint64 bound t = Common.next_bounded_uint64 bound ~nextu64:next_uint64 t
+
+
     let advance d t =
         (* Split 128bit [d] into [lower, high] 64-bit integers. *)
         let d0, d1 = Uint128.(rem d (of_uint64 Uint64.max_int) |> to_uint64,

--- a/lib/pcg.ml
+++ b/lib/pcg.ml
@@ -77,13 +77,7 @@ end = struct
         {state = (increment + s) * multiplier + increment; increment}
 
 
-    let next_bounded_uint64 bound t =
-        let rec loop threshold = function
-            | r, s when r >= threshold -> s, r
-            | _, s -> loop threshold (next s)
-        in
-        let s, r' = loop (Uint64.rem (Uint64.neg bound) bound) (next t.s) in
-        Uint64.rem r' bound, {t with s} 
+    let next_bounded_uint64 bound t = Common.next_bounded_uint64 bound ~nextu64:next_uint64 t
 
 
     let initialize seed =

--- a/lib/philox.ml
+++ b/lib/philox.ml
@@ -98,6 +98,9 @@ end = struct
     let next_double t = Common.next_double ~nextu64:next_uint64 t
 
 
+    let next_bounded_uint64 bound t = Common.next_bounded_uint64 bound ~nextu64:next_uint64 t
+
+
     let jump t =
         let c2' = Uint64.(t.ctr.(2) + one) in match Uint64.(c2' = zero) with
         | true -> {t with ctr = [|t.ctr.(0); t.ctr.(1); c2'; Uint64.(t.ctr.(3) + one)|]}

--- a/lib/sfc.ml
+++ b/lib/sfc.ml
@@ -40,6 +40,9 @@ end = struct
     let next_double t = Common.next_double ~nextu64:next_uint64 t
 
 
+    let next_bounded_uint64 bound t = Common.next_bounded_uint64 bound ~nextu64:next_uint64 t
+
+
     let set_seed (w, x, y) =
         let rec loop s = function
             | 0 -> s

--- a/lib/xoshiro.ml
+++ b/lib/xoshiro.ml
@@ -55,6 +55,9 @@ end = struct
     let next_double t = Common.next_double ~nextu64:next_uint64 t
 
 
+    let next_bounded_uint64 bound t = Common.next_bounded_uint64 bound ~nextu64:next_uint64 t
+
+
     let jump = Uint64.(
         [| of_int 0x180ec6d33cfd0aba; of_string "0xd5a61266f0c9392c";
            of_string "0xa9582618e03fc9aa"; of_int 0x39abdc4529b1661c |])

--- a/test/test_chacha.ml
+++ b/test/test_chacha.ml
@@ -12,6 +12,9 @@ let test_chacha_datasets _ =
         (Sys.getcwd () ^ "/../../../test/data/chacha-testset-2.csv")
 
 
+let test_bounded_u64 _ = Testconf.test_bounded_u64 (module ChaCha)
+
+
 let test_full_init _ =
     let ss = SeedSequence.initialize [Uint128.of_int 12345] in
     let full = ChaCha.(initialize_full ss Uint64.(max_int, zero) 4 |> next_uint64)
@@ -57,4 +60,5 @@ let tests = [
     "test ChaCha full initialization consistency" >:: test_full_init;
     "test if odd number of rounds raises exception" >:: test_invalid_round;
     "test the correctness of ChaCha's advance function" >:: test_advance;
+    "test bounded random generation of ChaCha" >:: test_bounded_u64;
 ]

--- a/test/test_pcg.ml
+++ b/test/test_pcg.ml
@@ -16,20 +16,6 @@ let test_advance _ =
         ~printer:(fun x -> x)
 
 
-let test_bounded_u64 _ =
-    let open Stdint in
-    let rec loop i t b acc n = match i >= n with
-        | true -> List.fold_left ( && ) true (List.rev acc)
-        | false ->
-            let u, t' = PCG64.next_bounded_uint64 b t in
-            loop (i + 1) t' b ((u < b) :: acc) n
-    in
-    let t = SeedSequence.initialize [Uint128.of_int 12345] |> PCG64.initialize in
-    List.iter
-        (fun b -> assert_equal true (loop 0 t (Uint64.of_int b) [] 1000))
-        [1; 1000; 4193609425186963870]
-
-
 let test_pcg_datasets _ =
     Testconf.bitgen_groundtruth
         (module PCG64)
@@ -37,6 +23,9 @@ let test_pcg_datasets _ =
     Testconf.bitgen_groundtruth
         (module PCG64)
         (Sys.getcwd () ^ "/../../../test/data/pcg64-testset-2.csv")
+
+
+let test_bounded_u64 _ = Testconf.test_bounded_u64 (module PCG64)
 
 
 let tests = [

--- a/test/test_philox.ml
+++ b/test/test_philox.ml
@@ -11,6 +11,9 @@ let test_philox_datasets _ =
         (Sys.getcwd () ^ "/../../../test/data/philox-testset-2.csv")
 
 
+let test_bounded_u64 _ = Testconf.test_bounded_u64 (module Philox4x64)
+
+
 let test_counter_init _ =
     let open Stdint in
     let ss = SeedSequence.initialize [Uint128.of_int 12345] in
@@ -54,4 +57,5 @@ let tests = [
     "test behaviour when counter is set" >:: test_counter_init;
     "test Philox jump function consistency" >:: test_jump;
     "test Philox advance function correctness" >:: test_advance;
+    "test bounded random generation of Philox" >:: test_bounded_u64;
 ]

--- a/test/test_sfc.ml
+++ b/test/test_sfc.ml
@@ -11,6 +11,10 @@ let test_sfc_datasets _ =
         (Sys.getcwd () ^ "/../../../test/data/sfc64-testset-2.csv")
 
 
+let test_bounded_u64 _ = Testconf.test_bounded_u64 (module SFC64)
+
+
 let tests = [
     "test SFC64's next_uint64 against groundtruth data" >:: test_sfc_datasets;
+    "test bounded random generation of SFC64" >:: test_bounded_u64;
 ]

--- a/test/test_xoshiro.ml
+++ b/test/test_xoshiro.ml
@@ -11,6 +11,9 @@ let test_xoshiro_datasets _ =
         (Sys.getcwd () ^ "/../../../test/data/xoshiro256-testset-2.csv")
 
 
+let test_bounded_u64 _ = Testconf.test_bounded_u64 (module Xoshiro256)
+
+
 let test_jump _ =
     let ss = SeedSequence.initialize [] in
     let t = Xoshiro256.initialize ss |> Xoshiro256.jump in
@@ -21,4 +24,5 @@ let test_jump _ =
 let tests = [
     "test Xoshiro256** PRNG against groundtruth datasets" >:: test_xoshiro_datasets;
     "test Xoshiro256** jump function consistency" >:: test_jump;
+    "test bounded random generation of Xoshiro256**" >:: test_bounded_u64;
 ]


### PR DESCRIPTION
This implementation uses Daniel Lemire's method, as shown [here](https://arxiv.org/abs/1805.10941). The functionality is added to the main bitgenerator
signature and thus supported by all implemented
PRNG bitgenerators.