### PR TITLE
Use `Option` type instead of a custom `store` type.

### DIFF
--- a/lib/common.ml
+++ b/lib/common.ml
@@ -1,11 +1,6 @@
 open Stdint
 
 
-type 'a store =
-    | Empty
-    | Value of 'a
-
-
 let maxint32 = Uint64.of_int 0xffffffff
 
 (* [to_uint32 nxt s store] advances state [s] and optains a random uint64 integers
@@ -15,11 +10,11 @@ let maxint32 = Uint64.of_int 0xffffffff
    [store] is returned and an empty store is returned to the caller. A 3-tuple is
    returned of the form: (new uint32, new state s, new store). *)
 let next_uint32 ~next s = function
-    | Value x -> x, s, Empty
-    | Empty ->
+    | Some x -> x, s, None
+    | None ->
         let uint, s' = next s in
         Uint64.(logand uint maxint32 |> to_uint32), s',
-        Value Uint64.(shift_right uint 32 |> to_uint32)
+        Some Uint64.(shift_right uint 32 |> to_uint32)
 
 
 (* [next_double nextu64 t] returns a random float from bitgenerator [t] using

--- a/lib/pcg.ml
+++ b/lib/pcg.ml
@@ -28,7 +28,7 @@ module PCG64 : sig
     (** [next_bounded_uint64 bound t] returns an unsigned 64bit integers in the range
         (0, bound) as well as the state of the generator advanced one step forward. *)
 end = struct
-    type t = {s : setseq; ustore : uint32 Common.store}
+    type t = {s : setseq; ustore : uint32 option}
     and setseq = {state : uint128; increment : uint128}
 
     let multiplier = Uint128.of_string "0x2360ed051fc65da44385df649fccf645"
@@ -87,5 +87,5 @@ end = struct
 
 
     let initialize seed =
-        {s = set_seed (Seed.SeedSequence.generate_64bit_state 4 seed); ustore = Common.Empty}
+        {s = set_seed (Seed.SeedSequence.generate_64bit_state 4 seed); ustore = None}
 end

--- a/lib/philox.ml
+++ b/lib/philox.ml
@@ -44,7 +44,7 @@ module Philox : sig
     val jump : t -> t
     (** [jump t] is equivalent to {m 2^{128}} calls to {!Philox64.next_uint64}. *)
 end = struct
-    type t = {key: key; ctr : counter; buffer : buffer; buffer_pos : int; ustore : uint32 Common.store}
+    type t = {key: key; ctr : counter; buffer : buffer; buffer_pos : int; ustore : uint32 option}
     and counter = uint64 array
     and key = uint64 array
     and buffer = uint64 array
@@ -102,7 +102,7 @@ end = struct
     let initialize_ctr ~counter:(w, x, y, z) seed =
         {buffer_pos = 4;
          ctr = [|w; x; y; z|];
-         ustore = Common.Empty;
+         ustore = None;
          buffer = Array.make 4 Uint64.zero;
          key = Seed.SeedSequence.generate_64bit_state 2 seed}
 

--- a/lib/sfc.ml
+++ b/lib/sfc.ml
@@ -19,7 +19,7 @@ module SFC64 : sig
     include Common.BITGEN
 end = struct
     (* last uint64 value is the counter *)
-    type t = {s : state; ustore : uint32 Common.store}
+    type t = {s : state; ustore : uint32 option}
     and state = uint64 * uint64 * uint64 * uint64
 
 
@@ -50,5 +50,5 @@ end = struct
 
     let initialize seed =
         let istate = Seed.SeedSequence.generate_64bit_state 3 seed in
-        {s = set_seed (istate.(0), istate.(1), istate.(2)); ustore = Common.Empty}
+        {s = set_seed (istate.(0), istate.(1), istate.(2)); ustore = None}
 end

--- a/lib/xoshiro.ml
+++ b/lib/xoshiro.ml
@@ -27,7 +27,7 @@ module Xoshiro256StarStar : sig
         it can be used to generate {m 2^{128}} non-overlapping subsequences for
         parallel computations. *)
 end = struct
-    type t = {s : state; ustore : uint32 Common.store}
+    type t = {s : state; ustore : uint32 option}
     and state = uint64 array
 
 
@@ -70,5 +70,5 @@ end = struct
 
 
     let initialize seed =
-        {s = Seed.SeedSequence.generate_64bit_state 4 seed; ustore = Common.Empty}
+        {s = Seed.SeedSequence.generate_64bit_state 4 seed; ustore = None}
 end


### PR DESCRIPTION
This simplifies differentiating if a bitgenerator
type has a stored uint32 integer or not. No need for a custom type when built-in option type encodes the information easily.