### PR TITLE
Simplify some recursive functions.

### DIFF
--- a/bin/bench.ml
+++ b/bin/bench.ml
@@ -20,7 +20,7 @@ let pairs = [
     "PCG64", (module PCG64: S);
     "SFC64", (module SFC64: S);
     "Xoshiro256", (module Xoshiro256: S);
-    "Philox64", (module Philox64: S);
+    "Philox4x64", (module Philox4x64: S);
     "ChaCha", (module ChaCha: S);
 ]
 

--- a/bin/crush.ml
+++ b/bin/crush.ml
@@ -49,7 +49,7 @@ let make_int32 (module M : S) ~rev =
 let to_module = function
     | "xoshiro256" -> (module Xoshiro256 : S)
     | "pcg64" -> (module PCG64 : S)
-    | "philox64" -> (module Philox64 : S)
+    | "philox4x64" -> (module Philox4x64 : S)
     | "sfc64" -> (module SFC64 : S)
     | "chacha" -> (module ChaCha : S)
     | _ -> failwith "Unknown PRNG"

--- a/lib/bitgen.ml
+++ b/lib/bitgen.ml
@@ -35,5 +35,5 @@ module SeedSequence = Seed.SeedSequence
 module SFC64 = Sfc.SFC64
 module PCG64 = Pcg.PCG64
 module Xoshiro256 = Xoshiro.Xoshiro256StarStar
-module Philox64 = Philox.Philox
+module Philox4x64 = Philox.Philox
 module ChaCha = Chacha.ChaCha128Counter

--- a/lib/chacha.ml
+++ b/lib/chacha.ml
@@ -68,11 +68,10 @@ end = struct
     let indices = [|(0, 4, 8, 12); (1, 5, 9, 13); (2, 6, 10, 14); (3, 7, 11, 15);
                     (0, 5, 10, 15); (1, 6, 11, 12); (2, 7, 8, 13); (3, 4, 9, 14)|]
 
-    let core block n =
-        let rec loop block0 = function
-            | 0 -> block0
-            | i -> loop (Array.fold_left quarter_round block0 indices) (i - 1)
-        in loop block n
+
+    let rec core block = function
+        | 0 -> block
+        | i -> core (Array.fold_left quarter_round block indices) (i - 1)
 
 
     let mask = Uint32.(max_int |> to_uint64)

--- a/test/test_philox.ml
+++ b/test/test_philox.ml
@@ -4,10 +4,10 @@ open Bitgen
 
 let test_philox_datasets _ =
     Testconf.bitgen_groundtruth
-        (module Philox64)
+        (module Philox4x64)
         (Sys.getcwd () ^ "/../../../test/data/philox-testset-1.csv");
     Testconf.bitgen_groundtruth
-        (module Philox64)
+        (module Philox4x64)
         (Sys.getcwd () ^ "/../../../test/data/philox-testset-2.csv")
 
 
@@ -15,8 +15,8 @@ let test_counter_init _ =
     let open Stdint in
     let ss = SeedSequence.initialize [Uint128.of_int 12345] in
     let next_int init =
-        Philox64.initialize_ctr ~counter:init ss 
-        |> Philox64.next_uint64 |> fst |> Uint64.to_string
+        Philox4x64.initialize_ctr ~counter:init ss 
+        |> Philox4x64.next_uint64 |> fst |> Uint64.to_string
     in
     let base = next_int Uint64.(max_int, max_int, max_int, max_int) in
     assert_bool "" (base <> next_int Uint64.(max_int, max_int, max_int, zero));
@@ -28,9 +28,9 @@ let test_counter_init _ =
 let test_jump _ =
     let open Stdint in
     let ss = SeedSequence.initialize [] in
-    let t = Philox64.initialize_ctr ~counter:Uint64.(max_int, max_int, max_int, max_int) ss |> Philox64.jump in
-    let t' = Philox64.initialize_ctr ~counter:Uint64.(max_int, max_int, zero, max_int) ss |> Philox64.jump in
-    assert_bool "" ((Philox64.next_double t |> fst) <> (Philox64.next_double t' |> fst))
+    let t = Philox4x64.initialize_ctr ~counter:Uint64.(max_int, max_int, max_int, max_int) ss |> Philox4x64.jump in
+    let t' = Philox4x64.initialize_ctr ~counter:Uint64.(max_int, max_int, zero, max_int) ss |> Philox4x64.jump in
+    assert_bool "" ((Philox4x64.next_double t |> fst) <> (Philox4x64.next_double t' |> fst))
 
 
 let test_advance _ =
@@ -40,12 +40,12 @@ let test_advance _ =
        steps used to call advance. *)
     let rec advance_n t = function
         | 0 -> t
-        | i -> advance_n (Philox64.next_uint64 t |> snd) (i - 1) in
+        | i -> advance_n (Philox4x64.next_uint64 t |> snd) (i - 1) in
     let t = SeedSequence.initialize [Uint128.of_int 12345]
-            |> Philox64.initialize_ctr ~counter:Uint64.(max_int, max_int, zero, zero) in
+            |> Philox4x64.initialize_ctr ~counter:Uint64.(max_int, max_int, zero, zero) in
     assert_equal
-        (Philox64.advance Uint64.(of_int 2, zero, zero, zero) t |> Philox64.next_uint64 |> fst |> Uint64.to_string)
-        (advance_n t (4 * 2) |> Philox64.next_uint64 |> fst |> Uint64.to_string)
+        (Philox4x64.advance Uint64.(of_int 2, zero, zero, zero) t |> Philox4x64.next_uint64 |> fst |> Uint64.to_string)
+        (advance_n t (4 * 2) |> Philox4x64.next_uint64 |> fst |> Uint64.to_string)
         ~printer:(fun x -> x)
 
 


### PR DESCRIPTION
Also rename Philox64 to the more descriptive Philox4x64.